### PR TITLE
Point to recommended host key option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To do this, start by generating the host keys locally:
 
 Then create a `Secret` from them:
 
-    create secret generic ssh-host-keys --from-file=ssh_host_ecdsa_key --from-file=ssh_host_ed25519_key --from-file=ssh_host_rsa_key
+    kubectl create secret generic ssh-host-keys --from-file=ssh_host_ecdsa_key --from-file=ssh_host_ed25519_key --from-file=ssh_host_rsa_key
 
 Finally, mount the secret as a volume in the pod to `/etc/ssh` (a complete example is below)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To avoid this, you have three choices:
 2. (not recommended) `UserKnownHostsFile /dev/null` in your `.ssh/config` or as a flag when connecting
 3. (really not recommended) Delete the relevant line from your `.ssh/known_hosts` any time this happens
 
-Option 3 is a bit more work, but a) still fairly easy and b) provides the best experience.
+Option 1 is a bit more work, but a) still fairly easy and b) provides the best experience.
 To do this, start by generating the host keys locally:
 
     ssh-keygen -f ssh_host_ecdsa_key -N '' -t ecdsa


### PR DESCRIPTION
Fix a typo in the sentence which should probably reference the
first, recommended option for host key management. Also
clarify the use of kubectl.